### PR TITLE
53 preserve options on load

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: msgr
 Title: Extends Messages, Warnings and Errors by Adding Levels and Log Files
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: person("Chad", "Goymer", email = "chad.goymer@gmail.com", role = c("aut", "cre"))
 Description: Provides new functions info(), warn() and error(), similar to message(),
     warning() and stop() respectively. However, the new functions can have a 'level'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# msgr 1.2.1
+
+- Do not override options if they are set before the package loads
+
 # msgr 1.2.0
 
 - Used `devtools::lint()` to follow tidyverse style guide

--- a/R/on-load.R
+++ b/R/on-load.R
@@ -15,33 +15,45 @@
 #
 .onLoad <- function(libname, pkgname) {
 
-  # Set default values for environment variables, if they have not been set
+  # Set message level
 
-  env <- list(
-    MSGR_LEVEL    = "1",
-    MSGR_TYPES    = "INFO|WARNING|ERROR",
-    MSGR_LOG_PATH = ""
-  )
-
-  toset <- sapply(names(env), function(e) identical(Sys.getenv(e), ""))
-  if (any(toset)) do.call(Sys.setenv, env[toset])
-
-  # Set package options from the environment variables
-
-  msgr_env <- as.list(Sys.getenv(names(env)))
-
-  types <- strsplit(msgr_env[["MSGR_TYPES"]], split = "\\|")[[1]]
-  if (identical(types, "NULL")) {
-    types <- NULL
+  if (is.null(getOption("msgr.level"))) {
+    if (Sys.getenv("MSGR_LEVEL") == "") {
+      level <- 1L
+    } else {
+      level <- suppressWarnings(as.integer(Sys.getenv("MSGR_LEVEL")))
+    }
+    options(msgr.level = level)
   }
 
-  options(
-    msgr.level    = suppressWarnings(as.integer(msgr_env[["MSGR_LEVEL"]])),
-    msgr.types    = types,
-    msgr.log_path = normalizePath(
-      msgr_env[["MSGR_LOG_PATH"]], winslash = "/", mustWork = FALSE
-    )
-  )
+  # Set message types
+
+  if (is.null(getOption("msgr.types"))) {
+    if (Sys.getenv("MSGR_TYPES") == "") {
+      types <- c("INFO", "WARNING", "ERROR")
+    } else {
+      types <- strsplit(Sys.getenv("MSGR_TYPES"), split = "\\|")[[1]]
+      if (identical(types, "NULL")) {
+        types <- NULL
+      }
+    }
+    options(msgr.types = types)
+  }
+
+  # Set log file path
+
+  if (is.null(getOption("msgr.log_path"))) {
+    if (Sys.getenv("MSGR_LOG_PATH") == "") {
+      log_path <- ""
+    } else {
+      log_path <- normalizePath(
+        Sys.getenv("MSGR_LOG_PATH"),
+        winslash = "/",
+        mustWork = FALSE
+      )
+    }
+    options(msgr.log_path = log_path)
+  }
 
 }
 

--- a/tests/testthat/test-on-load.R
+++ b/tests/testthat/test-on-load.R
@@ -1,7 +1,39 @@
 
 # TEST: .onLoad ----------------------------------------------------------------
 
-test_that("Options are set when package is loaded", {
+test_that("Default options are set when package is loaded", {
+
+  original_env_vars <- list(
+    MSGR_LEVEL    = Sys.getenv("MSGR_LEVEL"),
+    MSGR_TYPES    = Sys.getenv("MSGR_TYPES"),
+    MSGR_LOG_PATH = Sys.getenv("MSGR_LOG_PATH")
+  )
+
+  original_options <- options(
+    msgr.level    = NULL,
+    msgr.types    = NULL,
+    msgr.log_path = NULL
+  )
+
+  on.exit({
+    do.call(Sys.setenv, original_env_vars)
+    do.call(options, original_options)
+    .onLoad()
+  })
+
+  Sys.setenv(MSGR_LEVEL    = "")
+  Sys.setenv(MSGR_TYPES    = "")
+  Sys.setenv(MSGR_LOG_PATH = "")
+
+  .onLoad()
+
+  expect_identical(getOption("msgr.level"), 1L)
+  expect_identical(getOption("msgr.types"), c("INFO", "WARNING", "ERROR"))
+  expect_identical(getOption("msgr.log_path"), "")
+
+})
+
+test_that("Options are overidden when environment variables are set", {
 
   original_env_vars <- list(
     MSGR_LEVEL    = Sys.getenv("MSGR_LEVEL"),
@@ -30,6 +62,34 @@ test_that("Options are set when package is loaded", {
   expect_identical(getOption("msgr.level"), 10L)
   expect_null(getOption("msgr.types"))
   expect_identical(getOption("msgr.log_path"), "C:/temp/test-msgr.log")
+
+})
+
+test_that("Options are overidden when options are set", {
+
+  original_env_vars <- list(
+    MSGR_LEVEL    = Sys.getenv("MSGR_LEVEL"),
+    MSGR_TYPES    = Sys.getenv("MSGR_TYPES"),
+    MSGR_LOG_PATH = Sys.getenv("MSGR_LOG_PATH")
+  )
+
+  original_options <- options(
+    msgr.level    = 5L,
+    msgr.types    = "INFO",
+    msgr.log_path = "C:/temp/test.log"
+  )
+
+  on.exit({
+    do.call(Sys.setenv, original_env_vars)
+    do.call(options, original_options)
+    .onLoad()
+  })
+
+  .onLoad()
+
+  expect_identical(getOption("msgr.level"), 5L)
+  expect_identical(getOption("msgr.types"), "INFO")
+  expect_identical(getOption("msgr.log_path"), "C:/temp/test.log")
 
 })
 


### PR DESCRIPTION
## Summary

Do not override options if they are set before the package loads

Resolves: #53 
